### PR TITLE
Updated version of diagnostic-settings from 6.2.0 to 6.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+Changed
+* [GH-3](https://github.com/claranet/terraform-azurerm-cdn-frontdoor/pull/3): Bump diagnostic settings version to 6.5.0
+
 # v7.2.0 - 2023-04-07
 
 Breaking


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes proposed in this pull request

- Diagnostic-settings version 6.2.0 was specified as old, updated to 6.5.0.
  - If they remain out of date, the following errors and warnings occur

```
│ Warning: Argument is deprecated
│ 
│   with module.cdn_frontdoor_standard.module.diagnostics.azurerm_monitor_diagnostic_setting.main[0],
│   on .terraform/modules/cdn_frontdoor.diagnostics/r-diagnostic.tf line 7, in resource "azurerm_monitor_diagnostic_setting" "main":
│    7: resource "azurerm_monitor_diagnostic_setting" "main" {
│ 
│ `retention_policy` has been deprecated in favor of `azurerm_storage_management_policy` resource - to learn more
│ https://aka.ms/diagnostic_settings_log_retention
```
```
│ Error: creating Monitor Diagnostics Setting "default" for Resource "/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Cdn/profiles/xxxx": diagnosticsettings.DiagnosticSettingsClient#CreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="BadRequest" Message="Diagnostic settings does not support retention for new diagnostic settings."
```

@claranet/fr-azure-reviewers
